### PR TITLE
Escaping script tags

### DIFF
--- a/modules/_object-create.js
+++ b/modules/_object-create.js
@@ -20,7 +20,7 @@ var createDict = function(){
   // html.removeChild(iframe);
   iframeDocument = iframe.contentWindow.document;
   iframeDocument.open();
-  iframeDocument.write('<script>document.F=Object</script' + gt);
+  iframeDocument.write('<\script>document.F=Object<\/script' + gt);
   iframeDocument.close();
   createDict = iframeDocument.F;
   while(i--)delete createDict[PROTOTYPE][enumBugKeys[i]];


### PR DESCRIPTION
We experienced Issues while injecting this code inline. Browsers were able to interpret it correctly, but the facebook parser stumbled upon the unescaped script tags.
